### PR TITLE
Change to epsg:4269 in WaterData request

### DIFF
--- a/hydrodata/hydrodata.py
+++ b/hydrodata/hydrodata.py
@@ -375,7 +375,7 @@ class NWIS:
 
         sites = sites[sites.site_no.apply(len) == 8]
 
-        gii = WaterData("gagesii", "epsg:900913")
+        gii = WaterData("gagesii", "epsg:4269")
         hcdn = gii.byid("staid", sites.site_no.tolist())
         hcdn_dict = hcdn[["staid", "hcdn_2009"]].set_index("staid").hcdn_2009.to_dict()
         sites["hcdn_2009"] = sites.site_no.apply(


### PR DESCRIPTION
It looks like the USGS GeoServer layers were changed in the last 24 hours!! They no longer support epsg:900913 (web mercator), and now only accept epsg:4269. `NWIS.get_info` now fails because of this. I updated the epsg code on the WaterData call, and that should fix it. I've run WaterData calls with epsg:4269 on other layers (FYI, huc12) and it works.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [ ] Tests added and passed `make coverage`
 - [ ] Passes `make lint`
 - [ ] User visible changes (including notable bug fixes) are documented in `HISTORY.rst`
 - [ ] After adding new functions/methods ran `make apidocs`
